### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ It will schedule your local notification,
  It will check if we have any local notification scheduled, if the notification has not been triggered, it will reset it.
 
 
-###Properties
+### Properties
 ```objective-c
 @property (nonatomic, strong) NSArray* messages;
 ```
@@ -74,7 +74,7 @@ The array of time periods is sequential, if the attribute is set to YES when the
 
 This attribute define the domain of your notifications, to prevent collisions.
 
-####Example
+#### Example
 ```objective-c
     ACPReminder * localNotifications = [ACPReminder sharedManager];
     


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
